### PR TITLE
Ignore if this ends up in the actual Paradise Git.

### DIFF
--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -113,15 +113,15 @@ field_generator power level display
 	if(!I.tool_use_check(user, 0))
 		return
 	if(state == FG_SECURED)
-		WELDER_ATTEMPT_FLOOR_SLICE_MESSAGE
-	else if(state == FG_WELDED)
 		WELDER_ATTEMPT_FLOOR_WELD_MESSAGE
+	else if(state == FG_WELDED)
+		WELDER_ATTEMPT_FLOOR_SLICE_MESSAGE
 	if(I.use_tool(src, user, 20, volume = I.tool_volume))
 		if(state == FG_SECURED)
-			WELDER_FLOOR_SLICE_SUCCESS_MESSAGE
+			WELDER_FLOOR_WELD_SUCCESS_MESSAGE
 			state = FG_WELDED
 		else if(state == FG_WELDED)
-			WELDER_FLOOR_WELD_SUCCESS_MESSAGE
+			WELDER_FLOOR_SLICE_SUCCESS_MESSAGE
 			state = FG_SECURED
 
 /obj/machinery/field/generator/emp_act()


### PR DESCRIPTION
### 
Just a tiny fix.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
It simply swaps the SLICE and WELD messages in field_generator.dm to properly reflect what is actually happening when you interact with the object. While not a needed or pressing change, i do believe it is a good one.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
While it might be a small fix, it is one that hopefully clears up what they actually did to the field generators incase that the swapped messages got them confused. I for one did not even know it was like this until it was pointed out to me.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Simply swapped WELD and SLICE message calls in order to correctly represent what actually happens.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
